### PR TITLE
Change QPACK index wrapping starting point: issue #1644

### DIFF
--- a/interim-18-09/agenda.md
+++ b/interim-18-09/agenda.md
@@ -28,7 +28,7 @@ _19-20 September_
 Discussion will include (with the person leading the discussion):
 
 * Issues summary (Martin)
-* QPACK index wrapping (#1657) (Alan)
+* QPACK index wrapping ([#1644](https://github.com/quicwg/base-drafts/issues/1644)) (Alan)
 * Flow control gotchas (Mike)
 * max_bytes_before_ack (#1715) (Ian)
 * max ack delay (Ian/Jana)


### PR DESCRIPTION
Issue #1644 contains the pretty proposal and elucidating discussion, whereas the PR is full of draft minutia. The issue, therefore, is a better starting point to list on the agenda for the purposes of background.

(This change is submitted with @afrind's approval).