### PR TITLE
Add remote debugging session info

### DIFF
--- a/interim-19-01/agenda.md
+++ b/interim-19-01/agenda.md
@@ -49,9 +49,6 @@ _~15 minutes_
 - Next interop
 - Getting done
 
-### Remote presentations
-* 16:00-16:15 (try 30th, fallback 31st) : QUIC logging, debugging and tooling (Robin Marx)
-
 ### As Time Permits
 
-_none yet_
+* 16:00-16:15 (try 30th, fallback 31st) : QUIC logging, debugging and tooling (Robin Marx)

--- a/interim-19-01/agenda.md
+++ b/interim-19-01/agenda.md
@@ -49,6 +49,9 @@ _~15 minutes_
 - Next interop
 - Getting done
 
+### Remote presentations
+* 16:00-16:15 (try 30th, fallback 31st) : QUIC logging, debugging and tooling (Robin Marx)
+
 ### As Time Permits
 
 _none yet_


### PR DESCRIPTION
Given the time difference between Belgium and Tokyo (8 hours) a 4PM timeslot seems best. 3PM is probably the earliest I can really do. 

I would propose to try on the first day and if it gets pushed off the schedule by the other issues, try again on the second.
I am also free at that timeslot the 28th and 29th, if those would be better. 

I currently plan to keep the presentation short (5 - 10 minutes) with hopefully a little bit of time for initial feedback. 