### PR TITLE
Add qlog as agenda item

### DIFF
--- a/ietf109/agenda.md
+++ b/ietf109/agenda.md
@@ -60,3 +60,5 @@
 * 5+5 min - Discussion of the [Network Address Translation Support for QUIC](https://tools.ietf.org/html/draft-duke-quic-natsupp) draft - *Martin Duke* 
 
 * 5+5 min - Discussion of the [0-RTT-BDP](https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp) draft - *Nicolas Kuhn*
+
+* 5+5 min - Discussion of how to progress qlog ([main schema](https://tools.ietf.org/html/draft-marx-qlog-main-schema), [QUIC and HTTP/3 events](https://tools.ietf.org/html/draft-marx-qlog-event-definitions-quic-h3)) - *Robin Marx*


### PR DESCRIPTION
I will post an update on this on the mailing list in the coming days as well. 

With draft-02, the qlog project is currently in a state that it is difficult to have meaningful progression without added community involvement. This could take many shapes (adoption by the wg, design team, separate IETF BOF/WG, an (informal) interim, simply more people interacting with the personal drafts, ...) and I think it's useful to get an idea of what the broader QUIC community thinks about this at this point.