### PR TITLE
Extend QUIC-LB to 30 min

### DIFF
--- a/ietf110/agenda.md
+++ b/ietf110/agenda.md
@@ -27,7 +27,7 @@
 
 ### WG Items
 
-* 15 min - Open issues, implementation experience, possible WGLC of [QUIC-LB](https://datatracker.ietf.org/doc/draft-ietf-quic-load-balancers) - *Martin Duke*
+* 30 min - Open issues, implementation experience, possible WGLC of [QUIC-LB](https://datatracker.ietf.org/doc/draft-ietf-quic-load-balancers) - *Martin Duke*
 * 30 min - Open issues, updates to [DATAGRAM](https://datatracker.ietf.org/doc/draft-ietf-quic-datagram/) - *Tommy Pauly*
 * 30 min - Open issues, updates to [version negotiation](https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/) - *David Schinazi*
 


### PR DESCRIPTION
I would like to spend a little more time bringing people up to speed on QUIC-LB, instead of just discussing open issues. I think this takes us to 125 minutes, so I guess I could settle for 25. Do Tommy and David really need 30 min each?