### PR TITLE
Give all adopted items 25 mins and reshuffle order

### DIFF
--- a/ietf110/agenda.md
+++ b/ietf110/agenda.md
@@ -26,10 +26,10 @@
 * 5 min - Recap of interpo at hackathon ([interop sheet](https://docs.google.com/spreadsheets/d/1D0tW89vOoaScs3IY9RGC0UesWGAwE6xyLk0l4JtvTVg/edit#gid=1991873121)) - *Lars Eggert*
 
 ### WG Items
-* 20 min - WGLC changes to [manageability](https://datatracker.ietf.org/doc/draft-ietf-quic-manageability/) and [applicability](https://datatracker.ietf.org/doc/draft-ietf-quic-applicability/)
-* 15 min - Open issues, implementation experience, possible WGLC of [QUIC-LB](https://datatracker.ietf.org/doc/draft-ietf-quic-load-balancers) - *Martin Duke*
-* 30 min - Open issues, updates to [DATAGRAM](https://datatracker.ietf.org/doc/draft-ietf-quic-datagram/) - *Tommy Pauly*
-* 30 min - Open issues, updates to [version negotiation](https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/) - *David Schinazi*
+* 25 min - WGLC changes to [manageability](https://datatracker.ietf.org/doc/draft-ietf-quic-manageability/) and [applicability](https://datatracker.ietf.org/doc/draft-ietf-quic-applicability/)
+* 25 min - Open issues, updates to [DATAGRAM](https://datatracker.ietf.org/doc/draft-ietf-quic-datagram/) - *Tommy Pauly*
+* 25 min - Open issues, updates to [version negotiation](https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/) - *David Schinazi*
+* 25 min - Open issues, implementation experience, possible WGLC of [QUIC-LB](https://datatracker.ietf.org/doc/draft-ietf-quic-load-balancers) - *Martin Duke*
 
 ### Other (aka "As Time Permits")
 


### PR DESCRIPTION
Now that we have slides, we have a better idea of the scope of discussion for each specification.

Taking @tfpauly's suggestion from https://github.com/quicwg/wg-materials/pull/194#issuecomment-791510584, this PR rebalances the time across items and shuffles the ordering a bit to give QUIC LB time at the end.