### PR TITLE
ietf117: 10 mins less for stream resets, 10 mins more for NAT traversal

### DIFF
--- a/ietf117/agenda.md
+++ b/ietf117/agenda.md
@@ -23,11 +23,11 @@
 
 ### WG Items
 * 30 min - Open issues, updates to [multipath QUIC](https://datatracker.ietf.org/doc/html/draft-ietf-quic-multipath).
-* 30 min - Open issues, updates to [Reliable Stream Resets](https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/). 
+* 20 min - Open issues, updates to [Reliable Stream Resets](https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/). 
 * 15 min - Open issues, updates to [qlog](https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema).
 * 10 min - Open issues, updates to [Acknowledgement frequency](https://datatracker.ietf.org/doc/html/draft-ietf-quic-ack-frequency).
 * 5 min - Open issues, updates to [QUIC-LB](https://datatracker.ietf.org/doc/draft-ietf-quic-load-balancers/).
 
 ### Other (aka "As Time Permits")
 * 10 min - [QUIC-enabled Service Differentiation for Traffic Engineering](https://datatracker.ietf.org/doc/draft-zmlk-quic-te/)
-* 10 min - [QUIC NAT Traversal](https://datatracker.ietf.org/doc/draft-seemann-quic-nat-traversal/)
+* 20 min - [QUIC NAT Traversal](https://datatracker.ietf.org/doc/draft-seemann-quic-nat-traversal/)


### PR DESCRIPTION
I won’t need 30 mins for the stream resets, but more time to discuss NAT traversal would be very helpful.