### PR TITLE
Proposed congestion control requirement to recharter

### DIFF
--- a/charter/charter.md
+++ b/charter/charter.md
@@ -38,7 +38,8 @@ It is chartered to pursue work in the areas detailed below:
    can be adapted to work over a reliable and bidirectional byte stream
    substrate. When the substrate is insecure, TLS will be the default
    security provider; no effort will be made to enable unprotected
-   communication without a security provider. Substrates must provide congestion-management capabilities applicable to their deployment
+   communication without a security provider. Substrates must provide
+   congestion-management capabilities applicable to their deployment
    environments.
 
 Specifications describing how new or existing application protocols

--- a/charter/charter.md
+++ b/charter/charter.md
@@ -38,7 +38,8 @@ It is chartered to pursue work in the areas detailed below:
    can be adapted to work over a reliable and bidirectional byte stream
    substrate. When the substrate is insecure, TLS will be the default
    security provider; no effort will be made to enable unprotected
-   communication without a security provider.
+   communication without a security provider. Deployments on a shared
+   network must use a substrate that provides congestion control.
 
 Specifications describing how new or existing application protocols
 use the QUIC transport layer, called application protocol mappings

--- a/charter/charter.md
+++ b/charter/charter.md
@@ -38,8 +38,8 @@ It is chartered to pursue work in the areas detailed below:
    can be adapted to work over a reliable and bidirectional byte stream
    substrate. When the substrate is insecure, TLS will be the default
    security provider; no effort will be made to enable unprotected
-   communication without a security provider. Deployments on a shared
-   network must use a substrate that provides congestion control.
+   communication without a security provider. Substrates must provide congestion-management capabilities applicable to their deployment
+   environments.
 
 Specifications describing how new or existing application protocols
 use the QUIC transport layer, called application protocol mappings


### PR DESCRIPTION
I received an offlist comment about whether congestion control should be explicitly called out in the charter. 

As an individual my response to the question is: 

I don't think the reliable bidirectional stream itself needs to provide congestion control (e.g. TLS does not provide that itself, nor does it require it itself, but it does work on TCP which provides it). That said, in the prior work on [draft-kazuho-quic-quic-on-streams](https://datatracker.ietf.org/doc/html/draft-kazuho-quic-quic-on-streams#section-3.1) @kazuho and I stated that it was designed to work on a transport that is congestion controlled when using a shared network. The rationale being that we can have a simple design and remain Internet congestion safe by delegating the congestion control requrements to the substrate. 

This PR proposes an additional sentence to the charter to capture that we expect congestion control on shared networks.

This might be too broad brush for folks that were thinking of using RDMA, so pinging @nibanks . 

I'd like to keep any text in this realm succinct. 

One alternative to the "congestion control" phrase could to talk about the outcome we want to avoid:

"Deployments on a shared network must use a substrate that can avoid congesting the network."